### PR TITLE
fix: ensure we can detect the source ip

### DIFF
--- a/unifi_discovery/__init__.py
+++ b/unifi_discovery/__init__.py
@@ -31,6 +31,9 @@ class UnifiService(Enum):
 
 _LOGGER = logging.getLogger(__name__)
 
+BROADCAST_IP = "255.255.255.255"
+MDNS_TARGET_IP = "224.0.0.251"
+PUBLIC_TARGET_IP = "1.1.1.1"
 
 IGNORE_NETWORKS = (
     ip_network("169.254.0.0/16"),
@@ -349,7 +352,12 @@ class AIOUnifiScanner:
         found_all_future: "asyncio.Future[bool]",
     ) -> None:
         """Send the scans."""
-        self.source_ip = async_get_source_ip("255.255.255.255")
+        self.source_ip = (
+            async_get_source_ip(BROADCAST_IP)
+            or async_get_source_ip(MDNS_TARGET_IP)
+            or async_get_source_ip(PUBLIC_TARGET_IP)
+        )
+        _LOGGER.debug("source_ip: %s", self.source_ip)
         _LOGGER.debug("discover: %s => %s", destination, UBNT_REQUEST_PAYLOAD)
         transport.sendto(UBNT_REQUEST_PAYLOAD, destination)
         quit_time = time.monotonic() + timeout


### PR DESCRIPTION
Some systems cannot detect the source ip using 255.255.255.255, so we try the mdns ip, and then a public ip

Fixes failing to exclude the reflected broadcast looping back
```
2022-01-19 07:53:33 ERROR (MainThread) [unifi_discovery] Failed to get system info for 192.168.103.2
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/unifi_discovery/__init__.py", line 424, in _probe_services_and_system
    system = await system_response.json()
  File "/usr/local/lib/python3.9/site-packages/aiohttp/client_reqrep.py", line 1103, in json
    raise ContentTypeError(
aiohttp.client_exceptions.ContentTypeError: 0, message='Attempt to decode JSON with unexpected mimetype: text/html; charset="utf-8"', url=URL('https://192.168.103.2:5001/')
```