### PR TITLE
feat: parse additional UniFi OS console discovery fields

### DIFF
--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -99,6 +99,9 @@ async def test_async_scanner_specific_address(
             hostname="Gate",
             platform="UVC G4 Pro",
             model=None,
+            sysid=42339,
+            device_id="32f695ba-835b-5822-bc54-e290e1789ff1",
+            is_managed=True,
             signature_version="1",
         )
     ]
@@ -176,6 +179,8 @@ async def test_async_scanner_broadcast(mock_discovery_aio_protocol, mock_aioresp
             hostname="AlexanderTechRoom",
             platform="UFP-UAP-B",
             model="Unifi-Protect-UAP-Bridge",
+            sysid=8358,
+            is_managed=True,
             signature_version="1",
             services={
                 UnifiService.Protect: False,
@@ -253,6 +258,8 @@ async def test_async_scanner_no_system_response(
             hostname="AlexanderTechRoom",
             platform="UFP-UAP-B",
             model="Unifi-Protect-UAP-Bridge",
+            sysid=8358,
+            is_managed=True,
             signature_version="1",
             services={
                 UnifiService.Protect: False,
@@ -682,14 +689,14 @@ V0_RESPONSE = (
     b"v4.2.16"  # 0x16 version
 )
 
-# --- V2 response with unknown fields (seq, source_mac, is_default) ---
+# --- V2 response with unknown fields (seq, source_mac) ---
 V2_RESPONSE_WITH_EXTRA_FIELDS = (
     b"\x02\x06"  # version=2, command=6
     b"\x00\x1b"  # data_len=27
     b"\x01\x00\x06\xe0\x63\xda\x00\x5e\x08"  # 0x01 hw_addr (9 bytes)
     b"\x12\x00\x02\x00\x01"  # 0x12 seq=1 (5 bytes)
     b"\x13\x00\x06\xe0\x63\xda\x00\x5e\x08"  # 0x13 source_mac (9 bytes)
-    b"\x17\x00\x01\x00"  # 0x17 is_default=False (4 bytes)
+    b"\x17\x00\x01\x00"  # 0x17 is_managed (wire 0 = managed)
 )
 
 
@@ -716,6 +723,67 @@ def test_parse_v1_response():
     assert device.signature_version == "1"
     assert device.product_name is None
     assert device.version is None
+    # Cameras/APs omit 0x06, so no display name is parsed.
+    assert device.name is None
+
+
+def test_parse_console_display_name():
+    """0x06 carries the console display name (consoles only; cameras omit it)."""
+    payload = (
+        b"\x01\x00\x001"  # V1 header, command 0, data_len 0x31
+        b"\x01\x00\x06\xaa\xbb\xcc\xdd\xee\xff"  # 0x01 hw_addr
+        b"\x06\x00\x0bLiving Room"  # 0x06 display name
+        b"\x0b\x00\x0bLiving-Room"  # 0x0b hostname (hostname-safe form)
+        b"\x0c\x00\tUDMPROMAX"  # 0x0c platform
+    )
+    device = parse_ubnt_response(payload, ("192.168.1.1", DISCOVERY_PORT))
+    assert device is not None
+    assert device.name == "Living Room"
+    assert device.hostname == "Living-Room"
+    assert device.platform == "UDMPROMAX"
+    assert device.signature_version == "1"
+
+
+def _tlv(field_id: int, value: bytes) -> bytes:
+    return bytes([field_id]) + len(value).to_bytes(2, "big") + value
+
+
+def _v1_packet(*tlvs: bytes) -> bytes:
+    body = b"".join(tlvs)
+    return b"\x01\x00" + len(body).to_bytes(2, "big") + body
+
+
+def test_parse_console_enrichment_fields():
+    """Console packets expose sysid, device_id, guid, primary_addr, is_managed, dcd."""
+    payload = _v1_packet(
+        _tlv(0x01, bytes.fromhex("aabbccddeeff")),
+        _tlv(0x06, b"Living Room"),
+        _tlv(0x10, (0x1234).to_bytes(2, "little")),  # sysid is little-endian uint16
+        _tlv(0x17, b"\x00"),  # is_managed True (wire 0 = adopted/managed)
+        _tlv(0x20, b"DEVICEID123"),
+        _tlv(0x2B, b"12345678-1234-5678-1234-567812345678"),
+        _tlv(0x2F, bytes.fromhex("aabbccddeeff") + bytes([192, 168, 1, 1])),
+        _tlv(0x30, b"example.id.ui.direct"),
+    )
+    device = parse_ubnt_response(payload, ("192.168.1.1", DISCOVERY_PORT))
+    assert device is not None
+    assert device.sysid == 0x1234
+    assert device.is_managed is True
+    assert device.device_id == "DEVICEID123"
+    assert device.guid == "12345678-1234-5678-1234-567812345678"
+    assert device.primary_addr == "aa:bb:cc:dd:ee:ff;192.168.1.1"
+    assert device.direct_connect_domain == "example.id.ui.direct"
+
+
+def test_parse_guid_rejects_non_console_binary():
+    """0x2b is a 16-byte binary blob on non-consoles — it must not become a guid."""
+    payload = _v1_packet(
+        _tlv(0x01, bytes.fromhex("aabbccddeeff")),
+        _tlv(0x2B, bytes(range(16))),  # 16 raw bytes, not a UUID string
+    )
+    device = parse_ubnt_response(payload, ("192.168.1.1", DISCOVERY_PORT))
+    assert device is not None
+    assert device.guid is None
 
 
 def test_parse_v2_response():

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -195,6 +195,40 @@ async def test_async_scanner_broadcast(mock_discovery_aio_protocol, mock_aioresp
 
 
 @pytest.mark.asyncio
+async def test_async_scanner_direct_connect_domain_tlv_fallback(
+    mock_discovery_aio_protocol, mock_aioresponse
+):
+    """direct_connect_domain falls back to the discovery TLV when /api/system omits it."""
+    scanner = AIOUnifiScanner()
+    mock_aioresponse.get("https://192.168.203.5/proxy/protect/api", status=401)
+    mock_aioresponse.get("https://192.168.203.5/proxy/network/api", status=404)
+    mock_aioresponse.get("https://192.168.203.5/proxy/access/api", status=404)
+    mock_aioresponse.get(
+        "https://192.168.203.5/api/system",
+        payload={
+            "hardware": {"shortname": "UDMPROMAX"},
+            "name": "Console",
+            "mac": "aabbccddeeff",
+        },  # note: no directConnectDomain
+    )
+
+    # version (0x16) marks it a console so it gets probed; 0x30 carries the
+    # direct-connect domain that /api/system above omits.
+    payload = _v1_packet(
+        _tlv(0x01, bytes.fromhex("aabbccddeeff")),
+        _tlv(0x16, b"4.0.0"),
+        _tlv(0x30, b"fallback.id.ui.direct"),
+    )
+    task = asyncio.ensure_future(scanner.async_scan(timeout=0.01, consoles_only=False))
+    _, protocol = await mock_discovery_aio_protocol()
+    protocol.datagram_received(payload, ("192.168.203.5", DISCOVERY_PORT))
+    await task
+
+    assert len(scanner.found_devices) == 1
+    assert scanner.found_devices[0].direct_connect_domain == "fallback.id.ui.direct"
+
+
+@pytest.mark.asyncio
 async def test_async_scanner_no_system_response(
     mock_discovery_aio_protocol, mock_aioresponse
 ):
@@ -784,6 +818,17 @@ def test_parse_guid_rejects_non_console_binary():
     device = parse_ubnt_response(payload, ("192.168.1.1", DISCOVERY_PORT))
     assert device is not None
     assert device.guid is None
+
+
+def test_parse_guid_normalizes_to_canonical():
+    """A guid in a non-canonical representation is normalized to canonical form."""
+    payload = _v1_packet(
+        _tlv(0x01, bytes.fromhex("aabbccddeeff")),
+        _tlv(0x2B, b"{12345678-1234-5678-1234-567812345678}"),
+    )
+    device = parse_ubnt_response(payload, ("192.168.1.1", DISCOVERY_PORT))
+    assert device is not None
+    assert device.guid == "12345678-1234-5678-1234-567812345678"
 
 
 def test_parse_v2_response():

--- a/unifi_discovery/__init__.py
+++ b/unifi_discovery/__init__.py
@@ -15,6 +15,7 @@ from struct import Struct
 from struct import error as StructError
 from types import MappingProxyType
 from typing import TYPE_CHECKING, NamedTuple, cast
+from uuid import UUID
 
 from aiohttp import (
     ClientError,
@@ -131,14 +132,21 @@ _FIELD_IP_INFO = 0x02
 _FIELD_FW_VERSION = 0x03
 _FIELD_ADDR_ENTRY = 0x04
 _FIELD_MAC_ADDRESS = 0x05
+_FIELD_NAME = 0x06
 _FIELD_UPTIME = 0x0A
 _FIELD_HOSTNAME = 0x0B
 _FIELD_PLATFORM = 0x0C
+_FIELD_SYSID = 0x10
 _FIELD_MODEL = 0x14
 _FIELD_PRODUCT_NAME = 0x15
 _FIELD_VERSION = 0x16
-# Known protocol fields not mapped to UnifiDevice: 0x12 (seq), 0x13 (source_mac),
-# 0x17 (is_default). These are parsed by the device firmware but not exposed here.
+_FIELD_IS_MANAGED = 0x17
+_FIELD_DEVICE_ID = 0x20
+_FIELD_GUID = 0x2B
+_FIELD_PRIMARY_ADDR = 0x2F
+_FIELD_DIRECT_CONNECT_DOMAIN = 0x30
+# Known protocol fields not mapped to UnifiDevice: 0x12 (seq), 0x13 (source_mac).
+# These are parsed by the device firmware but not exposed here.
 
 
 def _parse_ip_info(data: bytes) -> str:
@@ -147,6 +155,30 @@ def _parse_ip_info(data: bytes) -> str:
 
 def _parse_uptime(data: bytes) -> int:
     return int.from_bytes(data, "big")
+
+
+def _parse_sysid(data: bytes) -> int:
+    # 0x10 is a little-endian uint16 hardware/model id.
+    return int.from_bytes(data, "little")
+
+
+def _parse_is_managed(data: bytes) -> bool:
+    # 0x17 reflects the device's managed/adopted state. It is observed as a zero
+    # byte on set-up/adopted consoles (sent as 1 byte, or 4 bytes on some
+    # devices), so a zero value is treated as managed and any non-zero value as
+    # unmanaged/factory-default.
+    return int.from_bytes(data, "big") == 0
+
+
+def _parse_guid(data: bytes) -> str:
+    # On UniFi OS consoles 0x2b is a 36-char UUID string. Non-console devices
+    # (cameras/APs/switches) reuse field id 0x2b for an unrelated 16-byte
+    # binary blob, so require a valid UUID string and let anything else raise
+    # (ValueError/UnicodeDecodeError) — the caller skips fields that fail to
+    # parse, so we never misinterpret a non-console payload as a guid.
+    text = data.decode()
+    UUID(text)
+    return text
 
 
 # field id -> (attribute name, parser (bytes -> value), may-repeat)
@@ -160,12 +192,22 @@ FIELD_PARSERS = {
     _FIELD_FW_VERSION: ("fw_version", bytes.decode, False),
     _FIELD_ADDR_ENTRY: ("addr_entry", ip_repr, False),
     _FIELD_MAC_ADDRESS: ("mac_address", mac_repr, False),
+    # 0x06 is the human-facing display name on UniFi OS consoles (e.g. "Living
+    # Room"); 0x0b is its hostname-safe form ("Living-Room"). Cameras and APs
+    # omit 0x06.
+    _FIELD_NAME: ("name", bytes.decode, False),
     _FIELD_UPTIME: ("uptime", _parse_uptime, False),
     _FIELD_HOSTNAME: ("hostname", bytes.decode, False),
     _FIELD_PLATFORM: ("platform", bytes.decode, False),
+    _FIELD_SYSID: ("sysid", _parse_sysid, False),
     _FIELD_MODEL: ("model", bytes.decode, False),
     _FIELD_PRODUCT_NAME: ("product_name", bytes.decode, False),
     _FIELD_VERSION: ("version", bytes.decode, False),
+    _FIELD_IS_MANAGED: ("is_managed", _parse_is_managed, False),
+    _FIELD_DEVICE_ID: ("device_id", bytes.decode, False),
+    _FIELD_GUID: ("guid", _parse_guid, False),
+    _FIELD_PRIMARY_ADDR: ("primary_addr", _parse_ip_info, False),
+    _FIELD_DIRECT_CONNECT_DOMAIN: ("direct_connect_domain", bytes.decode, False),
 }
 
 # (version, command) → signature label. All dispatches use FIELD_PARSERS.
@@ -199,12 +241,21 @@ class UnifiDevice:
     fw_version: str | None = None
     mac_address: str | None = None
     uptime: int | None = None
+    name: str | None = None
     hostname: str | None = None
     platform: str | None = None
     model: str | None = None
+    sysid: int | None = None
     signature_version: str | None = None
     services: Mapping[UnifiService, bool] = field(default_factory=_services_dict)
     direct_connect_domain: str | None = None
+    # Stable per-device identifiers and adoption state (consoles populate these;
+    # cameras/APs only set a subset). guid is a console-only UUID; device_id is
+    # present on most devices; primary_addr is the canonical "mac;ip".
+    device_id: str | None = None
+    guid: str | None = None
+    primary_addr: str | None = None
+    is_managed: bool | None = None
     is_sso_enabled: bool | None = None
     is_single_user: bool | None = None
     product_name: str | None = None
@@ -770,7 +821,8 @@ class AIOUnifiScanner:
             platform=device.platform or short_name,
             hostname=device.hostname or (system.get("name") or "").replace(" ", "-"),
             hw_addr=device.hw_addr or (_format_mac(mac) if mac else None),
-            direct_connect_domain=system.get("directConnectDomain"),
+            direct_connect_domain=system.get("directConnectDomain")
+            or device.direct_connect_domain,
             is_sso_enabled=system.get("isSsoEnabled"),
             is_single_user=system.get("isSingleUser"),
         )

--- a/unifi_discovery/__init__.py
+++ b/unifi_discovery/__init__.py
@@ -175,10 +175,9 @@ def _parse_guid(data: bytes) -> str:
     # (cameras/APs/switches) reuse field id 0x2b for an unrelated 16-byte
     # binary blob, so require a valid UUID string and let anything else raise
     # (ValueError/UnicodeDecodeError) — the caller skips fields that fail to
-    # parse, so we never misinterpret a non-console payload as a guid.
-    text = data.decode()
-    UUID(text)
-    return text
+    # parse, so we never misinterpret a non-console payload as a guid. Return
+    # the canonical form so the same id in any representation compares equal.
+    return str(UUID(data.decode()))
 
 
 # field id -> (attribute name, parser (bytes -> value), may-repeat)


### PR DESCRIPTION
## What

Parse additional fields from the UBNT discovery response into `UnifiDevice`:

- `name` (0x06) — the console's human-facing display name
- `sysid` (0x10) — hardware/model id (little-endian uint16)
- `device_id` (0x20) — per-device id (present on most devices)
- `guid` (0x2b) — console UUID
- `primary_addr` (0x2f) — canonical `mac;ip`
- `is_managed` (0x17) — adoption/managed state (observed as a zero byte on
  set-up consoles)
- `direct_connect_domain` (0x30) — now also read from the discovery packet
  (previously only from `/api/system`)

## Why

Consumers (e.g. the Home Assistant `unifi` / `unifiprotect` / `unifi_access`
integrations) currently only have `source_ip`, `hw_addr` and
`direct_connect_domain` to build a discovery entry from. With remote access
enabled this produces an unhelpful card title such as:

    default (<id>.id.ui.direct)

— a placeholder site name plus the opaque direct-connect host, with no hint of
which console it is. The discovery response already carries the console's
display name (0x06) and stable identifiers (0x2b / 0x20), so exposing them lets
a consumer show a friendly title (e.g. `Living Room (192.168.1.1)`) and use a
stable `unique_id`. `is_managed` additionally exposes the device's
adoption/managed state; how (or whether) a consumer acts on that is out of
scope here.

## Details

- The same field IDs are used across V1 and V2 console responses, so a single
  parser table covers both — no per-version mapping needed.
- `guid` (0x2b) uses a strict UUID parser: non-console devices
  (cameras/APs/switches) reuse field id 0x2b for an unrelated 16-byte binary
  blob, so anything that isn't a valid UUID string is skipped rather than
  misinterpreted.
- `direct_connect_domain` is read from the discovery packet, with the
  `/api/system` value preferred when the probe succeeds.

## Testing

- Added `test_parse_console_display_name`, `test_parse_console_enrichment_fields`
  and `test_parse_guid_rejects_non_console_binary`.
- Updated existing fixture expectations for the newly-parsed fields.
- Full suite passes; ruff lint + format clean.

## Checklist

- [x] Tests added
- [x] Docstrings on new functions
- [x] Works on supported Python versions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * UniFi device discovery now exposes additional device attributes including display name, system ID, managed state, device ID, GUID, primary address, and improved direct-connect domain enrichment.

* **Tests**
  * Updated and expanded unit tests to validate new enrichment fields for parsed devices, including direct-connect domain fallback behavior and GUID parsing/normalization edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->