### PR TITLE
fix: reap arp subprocess on timeout instead of suppressing TypeError

### DIFF
--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -3,7 +3,7 @@ import contextlib
 import logging
 import socket
 import time
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import pytest_asyncio
@@ -1457,3 +1457,22 @@ def test_async_clear_cache_drops_cache() -> None:
     unifi_discovery._scan_state.cache = (0.0, [])
     async_clear_cache()
     assert unifi_discovery._scan_state.cache is None
+
+
+@pytest.mark.asyncio
+async def test_arp_search_reaps_process_on_timeout():
+    """On arp timeout the child is killed and awaited, not left as a zombie."""
+    proc = MagicMock()
+    proc.communicate = AsyncMock(side_effect=asyncio.TimeoutError)
+    proc.kill = MagicMock()
+    proc.wait = AsyncMock()
+
+    with patch(
+        "unifi_discovery.asyncio.create_subprocess_exec",
+        AsyncMock(return_value=proc),
+    ):
+        result = await unifi_discovery.ArpSearch()._async_get_neighbors_arp()
+
+    assert result == {}
+    proc.kill.assert_called_once_with()
+    proc.wait.assert_awaited_once_with()

--- a/unifi_discovery/__init__.py
+++ b/unifi_discovery/__init__.py
@@ -548,10 +548,8 @@ class ArpSearch:
         try:
             out_data, _ = await asyncio.wait_for(arp.communicate(), ARP_TIMEOUT)
         except TimeoutError:
-            if arp:
-                with suppress(TypeError):
-                    await arp.kill()
-                del arp
+            arp.kill()
+            await arp.wait()
             return neighbours
         except AttributeError:
             return neighbours


### PR DESCRIPTION
On arp timeout the code did `with suppress(TypeError): await arp.kill()` followed by `del arp`. Process.kill() is synchronous and returns None, so awaiting it always raised the suppressed TypeError, and the killed child was never awaited so it could linger as a zombie. This calls `arp.kill()` directly and then `await arp.wait()` to reap it, and drops the dead `del arp`. Closes #149.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced subprocess termination and cleanup during ARP search timeout events, ensuring processes are properly terminated and fully reaped for complete resource release.

* **Tests**
  * Added test coverage to verify proper subprocess handling and resource cleanup when ARP search operations timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->